### PR TITLE
fixed lottery CORS

### DIFF
--- a/homeworks/week18/hw1/static/lottery.js
+++ b/homeworks/week18/hw1/static/lottery.js
@@ -1,5 +1,5 @@
 //  將固定網址及文字設為變數
-const API_URL = 'http://localhost:5003/lotteries/';
+const API_URL = 'http://restaurant.ahwei777.tw/lotteries';
 const errorMessage = '系統不穩定，請再試一次';
 //  設立一用來 call API 的函數，呼叫後會回傳 err(失敗)或經處理後的物件 json(成功)，後續再設定 callback function 處理回傳值
 function getPrize(cb) {


### PR DESCRIPTION
把 call 抽獎 api 的網址改成 'http://restaurant.ahwei777.tw/lotteries' ,
原本寫 'http://localhost:5003/lotteries/' ，但因為即使兩個地址都指向同一個 IP (一個為實際 IP 地址，一個為網域地址)，在 CORS 的認定上也是屬於跨域

> 在跨域问题上，域仅仅是通过"url的首部"来识别而不会去尝试判断相同的IP地址对应着两个域或者两个域是否同属同一个IP
[資料來源](https://blog.csdn.net/m0_37886429/article/details/83618506)